### PR TITLE
Evaluate zipped responses between the bridge and php-api

### DIFF
--- a/src/API/Query.php
+++ b/src/API/Query.php
@@ -61,6 +61,9 @@ class Query
     /** @var Serializer */
     private $serializer;
 
+    /** @var CompressResponse */
+    private $compressResponse = false;
+
     public function __construct()
     {
         $this->serializer = SerializerBuilder::create()->build();
@@ -476,6 +479,22 @@ class Query
     public function setPageSize($pageSize)
     {
         $this->pageSize = $pageSize;
+    }
+
+    /**
+     * @return CompressResponse
+     */
+    public function getCompressResponse()
+    {
+        return $this->compressResponse;
+    }
+
+    /**
+     * @param $pCompressResponse
+     */
+    public function setCompressResponse($pCompressResponse)
+    {
+        $this->compressResponse = $pCompressResponse;
     }
 
 }

--- a/tests/API/BridgeTest.php
+++ b/tests/API/BridgeTest.php
@@ -51,12 +51,15 @@ class BridgeTest extends PHPUnit_Framework_TestCase
 
     public function testGetNullJsonWhenInvalidJson()
     {
+        $headers = 'content-type:application/json\n';
+        $content = 'this is not JSON!';
         $http = Mockery::mock('API\Util\AbstractRequest');
         $http->shouldReceive('setOption');
         $http->shouldReceive('getHttpContentType')->andReturn('application/json');
         //we simulate a good query that returns 200
         $http->shouldReceive('getHttpStatusCode')->andReturn(200);
-        $http->shouldReceive('execute')->andReturn('this is not JSON!');
+        $http->shouldReceive('execute')->andReturn($headers . $content);
+        $http->shouldReceive('getInfo')->withArgs(array(CURLINFO_HEADER_SIZE))->andReturn(31);
         //create fake bridge with empty query, assign the mock http session, try to search, should get exception
         $myBridge = new Bridge('randomkey', 'somewhere', 9050);
         $myQuery = new Query();
@@ -64,6 +67,49 @@ class BridgeTest extends PHPUnit_Framework_TestCase
         $myBridge->setSession($http);
         $queryResult = $myBridge->search($myQuery);
         $this->assertNull($queryResult);
+    }
+
+    public function testSearchUncompressedResponse()
+    {
+        $headers = 'content-type:application/json\n';
+        $content = '{"query":"queryString"}';
+        $http = Mockery::mock('API\Util\AbstractRequest');
+        $http->shouldReceive('setOption');
+        $http->shouldReceive('getHttpContentType')->andReturn('application/json');
+        //we simulate a good query that returns 200
+        $http->shouldReceive('getHttpStatusCode')->andReturn(200);
+        $http->shouldReceive('execute')->andReturn($headers . $content);
+        $http->shouldReceive('getInfo')->withArgs(array(CURLINFO_HEADER_SIZE))->andReturn(31);
+
+        //create fake bridge with empty query, assign the mock http session, try to search, should not get exception
+        $myBridge = new Bridge('randomkey', 'somewhere', 9050);
+        $myQuery = new Query();
+
+        $myBridge->setSession($http);
+        $queryResult = $myBridge->search($myQuery);
+        $this->assertEquals("queryString", $queryResult->getQuery());
+    }
+
+    public function testSearchCompressedResponse()
+    {
+        $headers = 'content-encoding:gzip\n';
+        $content = '{"query":"queryString"}';
+        $contentCompressed = gzencode($content);
+        $http = Mockery::mock('API\Util\AbstractRequest');
+        $http->shouldReceive('setOption');
+        $http->shouldReceive('getHttpContentType')->andReturn('application/json');
+        //we simulate a good query that returns 200
+        $http->shouldReceive('getHttpStatusCode')->andReturn(200);
+        $http->shouldReceive('execute')->andReturn($headers . $contentCompressed);
+        $http->shouldReceive('getInfo')->withArgs(array(CURLINFO_HEADER_SIZE))->andReturn(23);
+
+        //create fake bridge with empty query, assign the mock http session, try to search, should not get exception
+        $myBridge = new Bridge('randomkey', 'somewhere', 9050);
+        $myQuery = new Query();
+        $myQuery->setCompressResponse(true);
+        $myBridge->setSession($http);
+        $queryResult = $myBridge->search($myQuery);
+        $this->assertEquals("queryString", $queryResult->getQuery());
     }
 
 //    public function testClusterSearch()


### PR DESCRIPTION
similar to iss809 in groupby/bindle, we would like to have a flag to allow user request compressed response
