### PR TITLE
PHP API and Quickstart Missing

### DIFF
--- a/src/API/AbstractBridge.php
+++ b/src/API/AbstractBridge.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace GroupByInc\API;
+
+use GroupByInc\API\Request\AbstractRequest;
+use GroupByInc\API\Request\CurlRequest;
+use RuntimeException;
+use JMS\Serializer\SerializerBuilder;
+use JMS\Serializer\Serializer;
+
+abstract class AbstractBridge
+{
+    const SEARCH = '/search';
+    const CLUSTER = '/cluster';
+    const HTTP = 'http://';
+    const HTTPS = 'https://';
+    const COLON = ':';
+
+    /** @var string */
+    private $clientKey;
+    /** @var string */
+    private $bridgeUrl;
+    /** @var string */
+    private $bridgeUrlCluster;
+    /** @var CurlRequest */
+    private $session;
+    /** @var CurlRequest */
+    private $sessionCluster;
+    /** @var Serializer */
+    private $serializer;
+
+    /**
+     * @param string $clientKey
+     * @param string $baseUrl
+     */
+    function __construct($clientKey, $baseUrl)
+    {
+        $this->clientKey = $clientKey;
+        $this->bridgeUrl = $baseUrl . self::SEARCH;
+        $this->bridgeUrlCluster = $baseUrl . self::CLUSTER;
+
+        $this->session = new CurlRequest($this->bridgeUrl);
+
+        $this->session->setOption(CURLOPT_HEADER, false)
+            ->setOption(CURLOPT_RETURNTRANSFER, true)
+            ->setOption(CURLOPT_HTTPHEADER, array("Content-type: application/json"))
+            ->setOption(CURLOPT_POST, true);
+
+        $this->sessionCluster = new CurlRequest($this->bridgeUrlCluster);
+
+        $this->sessionCluster->setOption(CURLOPT_HEADER, false)
+            ->setOption(CURLOPT_RETURNTRANSFER, true)
+            ->setOption(CURLOPT_HTTPHEADER, array("Content-type: application/json"))
+            ->setOption(CURLOPT_POST, true);
+
+        $this->serializer = SerializerBuilder::create()->build();
+    }
+
+    /**
+     * @param Query $query
+     * @return mixed
+     */
+    public function search($query)
+    {
+        $content = $query->getBridgeJson($this->clientKey);
+        $this->session->setOption(CURLOPT_POSTFIELDS, $content);
+        if ($query->getCompressResponse()) {
+            $this->session->setOption(CURLOPT_ENCODING, 'gzip');
+        } else {
+            $this->session->setOption(CURLOPT_ENCODING, '');
+        }
+
+        $json_response = $this->session->execute();
+        $status = $this->session->getHttpStatusCode();
+        $type = $this->session->getHttpContentType();
+
+        if ($json_response === false || $status != 200) {
+            throw new RuntimeException("Error: call to URL $this->bridgeUrl failed with status $status, response $json_response, curl_error " . $this->session->getError() . ", curl_errno " . $this->session->getErrorNumber());
+        }
+
+        if (!strstr($type, 'application/json')) {
+            throw new RuntimeException("Error: bridge at URL $this->bridgeUrl did not return the expected JSON response, it returned: " . $type . " instead");
+        }
+
+        $responseBody = $this->getBody($json_response);
+        if (strpos($this->getContentEncoding($json_response), 'gzip') !== FALSE) {
+            $responseBody = gzdecode($responseBody);
+        }
+
+        return $this->deserialize($responseBody);
+    }
+
+    private function getContentEncoding($response)
+    {
+        $headers = $this->getHeaders($response);
+        $arr = explode("\r\n", trim($headers));
+        foreach ($arr as $header) {
+            list($k, $v) = explode(':', $header);
+            if ('content-encoding' == strtolower($k)) {
+                return trim($v);
+            }
+        }
+        return false;
+    }
+
+    private function getHeaders($response)
+    {
+        $header_size = $this->session->getInfo(CURLINFO_HEADER_SIZE);
+        return substr($response, 0, $header_size);
+    }
+
+    private function getBody($response)
+    {
+        $header_size = $this->session->getInfo(CURLINFO_HEADER_SIZE);
+        return substr($response, $header_size);
+    }
+
+    private function deserialize($json)
+    {
+        $object = null;
+        try {
+            $object = $this->serializer->deserialize($json, 'GroupByInc\API\Model\Results', 'json');
+        } catch (RuntimeException $e) {
+            // should do something here
+        }
+        return $object;
+    }
+
+    /**
+     * @param AbstractRequest $session
+     */
+    public function setSession($session)
+    {
+        $this->session = $session;
+    }
+
+    /**
+     * @param AbstractRequest $session
+     */
+    public function setSessionCluster($session)
+    {
+        $this->sessionCluster = $session;
+    }
+}

--- a/src/API/Bridge.php
+++ b/src/API/Bridge.php
@@ -2,138 +2,15 @@
 
 namespace GroupByInc\API;
 
-use GroupByInc\API\Request\AbstractRequest;
-use GroupByInc\API\Request\CurlRequest;
-use RuntimeException;
-use JMS\Serializer\SerializerBuilder;
-use JMS\Serializer\Serializer;
-
-class Bridge
+class Bridge extends AbstractBridge
 {
-    /** @var string */
-    private $clientKey;
-    /** @var string */
-    private $bridgeUrl;
-    /** @var string */
-    private $bridgeUrlCluster;
-    /** @var CurlRequest */
-    private $session;
-    /** @var CurlRequest */
-    private $sessionCluster;
-    /** @var Serializer */
-    private $serializer;
-
     /**
      * @param string $clientKey
-     * @param string $host
-     * @param int    $port
+     * @param string $bridgeHost
+     * @param int $bridgePort
      */
-    function __construct($clientKey, $host, $port)
+    function __construct($clientKey, $bridgeHost, $bridgePort)
     {
-        $this->clientKey = $clientKey;
-        $this->bridgeUrl = "http://" . $host . ":" . $port . "/search";
-        $this->bridgeUrlCluster = "http://" . $host . ":" . $port . "/cluster";
-
-        $this->session = new CurlRequest($this->bridgeUrl);
-
-        $this->session->setOption(CURLOPT_HEADER, false)
-            ->setOption(CURLOPT_RETURNTRANSFER, true)
-            ->setOption(CURLOPT_HTTPHEADER, array("Content-type: application/json"))
-            ->setOption(CURLOPT_POST, true);
-
-        $this->sessionCluster = new CurlRequest($this->bridgeUrlCluster);
-
-        $this->sessionCluster->setOption(CURLOPT_HEADER, false)
-            ->setOption(CURLOPT_RETURNTRANSFER, true)
-            ->setOption(CURLOPT_HTTPHEADER, array("Content-type: application/json"))
-            ->setOption(CURLOPT_POST, true);
-
-        $this->serializer = SerializerBuilder::create()->build();
-    }
-
-    /**
-     * @param Query $query
-     * @return mixed
-     */
-    public function search($query)
-    {
-        $content = $query->getBridgeJson($this->clientKey);
-        $this->session->setOption(CURLOPT_POSTFIELDS, $content);
-        if ($query->getCompressResponse()) {
-            $this->session->setOption(CURLOPT_ENCODING, 'gzip');
-        } else {
-            $this->session->setOption(CURLOPT_ENCODING, '');
-        }
-
-        $json_response = $this->session->execute();
-        $status = $this->session->getHttpStatusCode();
-        $type = $this->session->getHttpContentType();
-
-        if ($json_response === false || $status != 200) {
-            throw new RuntimeException("Error: call to URL $this->bridgeUrl failed with status $status, response $json_response, curl_error " . $this->session->getError() . ", curl_errno " . $this->session->getErrorNumber());
-        }
-
-        if (!strstr($type, 'application/json')) {
-            throw new RuntimeException("Error: bridge at URL $this->bridgeUrl did not return the expected JSON response, it returned: " . $type . " instead");
-        }
-
-        $responseBody = $this->getBody($json_response);
-        if (strpos($this->getContentEncoding($json_response), 'gzip') !== FALSE) {
-            $responseBody = gzdecode($responseBody);
-        }
-
-        return $this->deserialize($responseBody);
-    }
-
-    private function getContentEncoding($response)
-    {
-        $headers = $this->getHeaders($response);
-        $arr = explode("\r\n", trim($headers));
-        foreach ($arr as $header) {
-            list($k, $v) = explode(':', $header);
-            if ('content-encoding' == strtolower($k)) {
-                return trim($v);
-            }
-        }
-        return false;
-    }
-
-    private function getHeaders($response)
-    {
-        $header_size = $this->session->getInfo(CURLINFO_HEADER_SIZE);
-        return substr($response, 0, $header_size);
-    }
-
-    private function getBody($response)
-    {
-        $header_size = $this->session->getInfo(CURLINFO_HEADER_SIZE);
-        return substr($response, $header_size);
-    }
-
-    private function deserialize($json)
-    {
-        $object = null;
-        try {
-            $object = $this->serializer->deserialize($json, 'GroupByInc\API\Model\Results', 'json');
-        } catch (RuntimeException $e) {
-            // should do something here
-        }
-        return $object;
-    }
-
-    /**
-     * @param AbstractRequest $session
-     */
-    public function setSession($session)
-    {
-        $this->session = $session;
-    }
-
-    /**
-     * @param AbstractRequest $session
-     */
-    public function setSessionCluster($session)
-    {
-        $this->sessionCluster = $session;
+        parent::__construct($clientKey, self::HTTP . $bridgeHost . self::COLON . $bridgePort);
     }
 }

--- a/src/API/CloudBridge.php
+++ b/src/API/CloudBridge.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace GroupByInc\API;
+
+class CloudBridge extends AbstractBridge
+{
+    const DOT = '.';
+    const CLOUD_HOST = 'groupbycloud.com';
+    const CLOUD_PORT = 443;
+    const CLOUD_PATH = 'api/v1';
+
+    /**
+     * @param string $clientKey
+     * @param string $customerId
+     */
+    function __construct($clientKey, $customerId)
+    {
+        parent::__construct($clientKey, self::HTTPS . $customerId . self::DOT . self::CLOUD_HOST . self::COLON . self::CLOUD_PORT . self::CLOUD_PATH);
+    }
+}

--- a/tests/API/CloudBridgeTest.php
+++ b/tests/API/CloudBridgeTest.php
@@ -1,0 +1,130 @@
+<?php
+
+use GroupByInc\API\Bridge;
+use GroupByInc\API\CloudBridge;
+use GroupByInc\API\Query;
+
+class CloudBridgeTest extends PHPUnit_Framework_TestCase
+{
+
+    public function testGetThrowsWhenStatusNot200()
+    {
+        $http = Mockery::mock('API\Util\AbstractRequest')->shouldDeferMissing();
+        $http->shouldReceive('getHttpStatusCode')->andReturn("not 200");
+        $http->shouldReceive('execute')->andReturn(true);
+        $this->setExpectedException('Exception');
+        //create fake bridge with empty query, assign the mock http session, try to search, should get exception
+        $myBridge = new CloudBridge('randomkey', 'somewhere');
+        $myQuery = new Query();
+        /** @noinspection PhpParamsInspection */
+        $myBridge->setSession($http);
+        $myBridge->search($myQuery);
+    }
+
+    public function testGetThrowsWhenExecReturnsFalse()
+    {
+        $http = Mockery::mock('API\Util\AbstractRequest');
+        $http->shouldReceive('execute')->andReturn(false);
+        $this->setExpectedException('Exception');
+        //create fake bridge with empty query, assign the mock http session, try to search, should get exception
+        $myBridge = new CloudBridge('randomkey', 'somewhere');
+        $myQuery = new Query();
+        /** @noinspection PhpParamsInspection */
+        $myBridge->setSession($http);
+        $myBridge->search($myQuery);
+    }
+
+    public function testGetThrowsWhenReturnBinary()
+    {
+        $http = Mockery::mock('API\Util\AbstractRequest');
+        $http->shouldReceive('getHttpContentType')->andReturn('not json');
+        //we simulate a good query that returns 200
+        $http->shouldReceive('getHttpStatusCode')->andReturn(200);
+        $http->shouldReceive('execute')->andReturn(true);
+        $this->setExpectedException('Exception');
+        //create fake bridge with empty query, assign the mock http session, try to search, should get exception
+        $myBridge = new CloudBridge('randomkey', 'somewhere');
+        $myQuery = new Query();
+        /** @noinspection PhpParamsInspection */
+        $myBridge->setSession($http);
+        $myBridge->search($myQuery);
+    }
+
+    public function testGetNullJsonWhenInvalidJson()
+    {
+        $headers = 'content-type:application/json\n';
+        $content = 'this is not JSON!';
+        $http = Mockery::mock('API\Util\AbstractRequest');
+        $http->shouldReceive('setOption');
+        $http->shouldReceive('getHttpContentType')->andReturn('application/json');
+        //we simulate a good query that returns 200
+        $http->shouldReceive('getHttpStatusCode')->andReturn(200);
+        $http->shouldReceive('execute')->andReturn($headers . $content);
+        $http->shouldReceive('getInfo')->withArgs(array(CURLINFO_HEADER_SIZE))->andReturn(31);
+        //create fake bridge with empty query, assign the mock http session, try to search, should get exception
+        $myBridge = new CloudBridge('randomkey', 'somewhere');
+        $myQuery = new Query();
+        /** @noinspection PhpParamsInspection */
+        $myBridge->setSession($http);
+        $queryResult = $myBridge->search($myQuery);
+        $this->assertNull($queryResult);
+    }
+
+    public function testSearchUncompressedResponse()
+    {
+        $headers = 'content-type:application/json\n';
+        $content = '{"query":"queryString"}';
+        $http = Mockery::mock('API\Util\AbstractRequest');
+        $http->shouldReceive('setOption');
+        $http->shouldReceive('getHttpContentType')->andReturn('application/json');
+        //we simulate a good query that returns 200
+        $http->shouldReceive('getHttpStatusCode')->andReturn(200);
+        $http->shouldReceive('execute')->andReturn($headers . $content);
+        $http->shouldReceive('getInfo')->withArgs(array(CURLINFO_HEADER_SIZE))->andReturn(31);
+
+        //create fake bridge with empty query, assign the mock http session, try to search, should not get exception
+        $myBridge = new CloudBridge('randomkey', 'somewhere');
+        $myQuery = new Query();
+
+        $myBridge->setSession($http);
+        $queryResult = $myBridge->search($myQuery);
+        $this->assertEquals("queryString", $queryResult->getQuery());
+    }
+
+    public function testSearchCompressedResponse()
+    {
+        $headers = 'content-encoding:gzip\n';
+        $content = '{"query":"queryString"}';
+        $contentCompressed = gzencode($content);
+        $http = Mockery::mock('API\Util\AbstractRequest');
+        $http->shouldReceive('setOption');
+        $http->shouldReceive('getHttpContentType')->andReturn('application/json');
+        //we simulate a good query that returns 200
+        $http->shouldReceive('getHttpStatusCode')->andReturn(200);
+        $http->shouldReceive('execute')->andReturn($headers . $contentCompressed);
+        $http->shouldReceive('getInfo')->withArgs(array(CURLINFO_HEADER_SIZE))->andReturn(23);
+
+        //create fake bridge with empty query, assign the mock http session, try to search, should not get exception
+        $myBridge = new CloudBridge('randomkey', 'somewhere');
+        $myQuery = new Query();
+        $myQuery->setCompressResponse(true);
+        $myBridge->setSession($http);
+        $queryResult = $myBridge->search($myQuery);
+        $this->assertEquals("queryString", $queryResult->getQuery());
+    }
+
+//    public function testClusterSearch()
+//    {
+//        $http = Mockery::mock('API\Util\AbstractRequest');
+//        $http->shouldReceive('setOption');
+//        $http->shouldReceive('getHttpStatusCode')->andReturn(200);
+//        $http->shouldReceive('execute')->andReturn(true);
+//        $http->shouldReceive('getHttpContentType')->andReturn('application/json');
+//        //create fake bridge with empty query, assign the mock http session, try to search, should not get exception
+//        $myBridge = new CloudBridge('randomkey', 'somewhere');
+//        $myQuery = new Query();
+//        /** @noinspection PhpParamsInspection */
+//        $myBridge->setSessionCluster($http);
+//        $myBridge->searchCluster($myQuery);
+//    }
+}


### PR DESCRIPTION
Created by: gpejski <img height="16px" src="https://avatars.githubusercontent.com/u/7842633?v=3">
Parent: groupby/issues#561

Austin Kayak is looking for the PHP API and QuickStart for the cloud. I had initially thought it could be found at https://github.com/groupby/api-php and https://github.com/groupby/quickstart-php, but nether of these seem to reference cloud bridge, so the code found there is out of date. Austin Kayak is waiting for this code before they can begin their integration.

@osman wasn't sure where this can be found and asked that I cc @effervescentia in this ticket.

Bonus points for adding SAYT to the PHP Quickstart.
