### PR TITLE
Quickstart to support more refinements (And PHP API)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,5 @@
+- <a href="https://github.com/groupby/issues/issues/720">iss11</a> Quickstart to support more refinements
+
 - <a href="https://github.com/groupby/issues/issues/672">iss10</a> RestrictNavigation for elasticsearch
 
 Changelog

--- a/src/API/Model/Navigation.php
+++ b/src/API/Model/Navigation.php
@@ -64,6 +64,11 @@ class Navigation
      */
     public $or = false;
     /**
+     * @var bool
+     * @JMS\Type("boolean")
+     */
+    public $moreRefinements = false;
+    /**
      * @var Refinement[]
      * @JMS\Type("array<GroupByInc\API\Model\Refinement>")
      */
@@ -84,6 +89,7 @@ class Navigation
 
     /**
      * @param string $name The name of the navigation.
+     *
      * @return Navigation
      */
     public function setName($name)
@@ -102,6 +108,7 @@ class Navigation
 
     /**
      * @param string $displayName Set the display name.
+     *
      * @return Navigation
      */
     public function setDisplayName($displayName)
@@ -120,6 +127,7 @@ class Navigation
 
     /**
      * @param Refinement[] $refinements The refinement values.
+     *
      * @return Navigation
      */
     public function setRefinements($refinements)
@@ -138,6 +146,7 @@ class Navigation
 
     /**
      * @param string $id Set the ID.
+     *
      * @return Navigation
      */
     public function setId($id)
@@ -156,6 +165,7 @@ class Navigation
 
     /**
      * @param bool $range Set range.
+     *
      * @return Navigation
      */
     public function setRange($range)
@@ -174,6 +184,7 @@ class Navigation
 
     /**
      * @param bool $or Set whether this is an OR field.
+     *
      * @return Navigation
      */
     public function setOr($or)
@@ -192,6 +203,7 @@ class Navigation
 
     /**
      * @param string $type Set the type of navigation.
+     *
      * @return Navigation
      */
     public function setType($type)
@@ -210,6 +222,7 @@ class Navigation
 
     /**
      * @param string $sort Set the sort type.
+     *
      * @return Navigation
      */
     public function setSort($sort)
@@ -228,11 +241,31 @@ class Navigation
 
     /**
      * @param Metadata[] $metadata Set the metadata.
+     *
      * @return Navigation
      */
     public function setMetadata($metadata)
     {
         $this->metadata = $metadata;
+        return $this;
+    }
+
+    /**
+     * @return bool True if this navigation has more refinement values than the ones returned, false otherwise.
+     */
+    public function getMoreRefinements()
+    {
+        return $this->moreRefinements;
+    }
+
+    /**
+     * @param bool $moreRefinements True if this navigation has more refinement values than the ones returned.
+     *
+     * @return $this
+     */
+    public function setMoreRefinements($moreRefinements)
+    {
+        $this->moreRefinements = $moreRefinements;
         return $this;
     }
 

--- a/src/API/Model/RefinementsResult.php
+++ b/src/API/Model/RefinementsResult.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace GroupByInc\API\Model;
+
+use JMS\Serializer\Annotation as JMS;
+
+class RefinementsResult
+{
+    /**
+     * @var string
+     * @JMS\Type("string")
+     */
+    public $errors;
+    /**
+     * @var Navigation
+     * @JMS\Type("GroupByInc\API\Model\Navigation")
+     */
+    public $navigation;
+
+    /**
+     * @return string
+     */
+    public function getErrors()
+    {
+        return $this->errors;
+    }
+
+    /**
+     * @param string $errors
+     */
+    public function setErrors($errors)
+    {
+        $this->errors = $errors;
+    }
+
+    /**
+     * @return Navigation
+     */
+    public function getNavigation()
+    {
+        return $this->navigation;
+    }
+
+    /**
+     * @param Navigation $navigation
+     */
+    public function setNavigation($navigation)
+    {
+        $this->navigation = $navigation;
+    }
+}
+

--- a/src/API/Request/RefinementsRequest.php
+++ b/src/API/Request/RefinementsRequest.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace GroupByInc\API\Request;
+
+use GroupByInc\API\Model\Navigation;
+use GroupByInc\API\Model\RestrictNavigation;
+use GroupByInc\API\Model\SelectedRefinement;
+
+class RefinementsRequest
+{
+    /** @var Request */
+    public $originalQuery;
+    /** @var string */
+    public $navigationName;
+}

--- a/src/API/Request/Request.php
+++ b/src/API/Request/Request.php
@@ -21,7 +21,7 @@ class Request
     /** @var string */
     public $query;
     /** @var string */
-    public $refinementSearch;
+    public $refinementQuery;
     /** @var Sort */
     public $sort;
 

--- a/tests/API/JsonDeserializeTest.php
+++ b/tests/API/JsonDeserializeTest.php
@@ -12,6 +12,7 @@ use GroupByInc\API\Model\PageInfo;
 use GroupByInc\API\Model\Record;
 use GroupByInc\API\Model\RecordsZone;
 use GroupByInc\API\Model\RefinementRange;
+use GroupByInc\API\Model\RefinementsResult;
 use GroupByInc\API\Model\RefinementValue;
 use GroupByInc\API\Model\RestrictNavigation;
 use GroupByInc\API\Model\Results;
@@ -32,11 +33,14 @@ class JsonDeserializeTest extends PHPUnit_Framework_TestCase
     public static $JSON_REFINEMENT_VALUE = '{"_id":"fadfs89y10j","count":987,"type":"Value","value":"malaise","exclude":false}';
     public static $JSON_REFINEMENT_RANGE = '{"high":"delicious","low":"atrocious","_id":"342h9582hh4","count":14,"type":"Range","exclude":true}';
     public static $JSON_PAGE_INFO = '{"recordStart":20,"recordEnd":50}';
+    public static $JSON_RESTRICT_NAVIGATION = '{"name":"categories","count":2}';
+    public static $JSON_CUSTOM_URL_PARAM = '{"key":"guava","value":"mango"}';
+    public static $JSON_SORT = '{"field":"price","order":"Descending"}';
     public static $JSON_RECORDS_ZONE;
     public static $JSON_TEMPLATE;
     public static $JSON_CLUSTER;
     public static $JSON_NAVIGATION;
-    public static $JSON_RESTRICT_NAVIGATION = '{"name":"categories","count":2}';
+    public static $JSON_REQUEST;
     /** @var Serializer */
     private static $serializer;
 
@@ -58,7 +62,16 @@ class JsonDeserializeTest extends PHPUnit_Framework_TestCase
         self::$JSON_NAVIGATION = '{"_id":"081h29n81f","name":"green","displayName":"GReeN",' .
             '"range":true,"or":false,"type":"Range_Date","sort":"Value_Ascending","refinements":[' .
             self::$JSON_REFINEMENT_RANGE . ',' . self::$JSON_REFINEMENT_VALUE .
-            '],"metadata":[' . self::$JSON_METADATA . ']}';
+            '],"metadata":[' . self::$JSON_METADATA . '],"moreRefinements":true}';
+
+        self::$JSON_REQUEST = '{"clientKey":"adf7h8er7h2r","collection":"ducks",' .
+            '"area":"surface","skip":12,"pageSize":30,"biasingProfile":"ballooning","language":"en",' .
+            '"pruneRefinements":true,"returnBinary":false,"query":"cantaloupe",' .
+            '"sort":' . self::$JSON_SORT . ',"fields":["pineapple","grape","clementine"],' .
+            '"orFields":["pumpernickel","rye"],"refinements":[' . self::$JSON_REFINEMENT_RANGE . ',' .
+            self::$JSON_REFINEMENT_VALUE . '],' . '"customUrlParams":[' . self::$JSON_CUSTOM_URL_PARAM .
+            '],' . '"restrictNavigation":' . self::$JSON_RESTRICT_NAVIGATION . ',"refinementQuery":"cranberry",' .
+            '"wildcardSearchEnabled":true}';
     }
 
     public function testDeserializeRefinementRange()
@@ -196,6 +209,19 @@ class JsonDeserializeTest extends PHPUnit_Framework_TestCase
 
         /** @var Results $results */
         $results = $this->deserialize($json, 'GroupByInc\API\Model\Results');
+        $this->assertEquals($expectedResults, $results);
+    }
+
+    public function testDeserializeRefinementsResult()
+    {
+        $expectedResults = new RefinementsResult();
+        $expectedResults->setErrors("Could not load");
+        $expectedResults->setNavigation(JsonSerializeTest::$OBJ_NAVIGATION);
+
+        $json = '{"errors":"Could not load","navigation":' . self::$JSON_NAVIGATION . '}';
+
+        /** @var RefinementsResult $results */
+        $results = $this->deserialize($json, 'GroupByInc\API\Model\RefinementsResult');
         $this->assertEquals($expectedResults, $results);
     }
 }

--- a/tests/API/JsonSerializeTest.php
+++ b/tests/API/JsonSerializeTest.php
@@ -18,6 +18,7 @@ use GroupByInc\API\Model\RichContentZone;
 use GroupByInc\API\Model\Template;
 use GroupByInc\API\Model\Zone;
 use GroupByInc\API\Request\CustomUrlParam;
+use GroupByInc\API\Request\RefinementsRequest;
 use GroupByInc\API\Request\Request;
 use GroupByInc\API\Request\Sort;
 use GroupByInc\API\Util\SerializerFactory;
@@ -55,12 +56,12 @@ class JsonSerializeTest extends PHPUnit_Framework_TestCase
     public static $OBJ_CUSTOM_URL_PARAM;
     /** @var Request */
     public static $OBJ_REQUEST;
+    /** @var RefinementsRequest */
+    public static $OBJ_REFINEMENTS_REQUEST;
     /** @var Sort */
     public static $OBJ_SORT;
     /** @var RestrictNavigation */
     public static $OBJ_RESTRICT_NAVIGATION;
-    private static $JSON_CUSTOM_URL_PARAM = '{"key":"guava","value":"mango"}';
-    private static $JSON_SORT = '{"field":"price","order":"Descending"}';
     /** @var Serializer */
     private static $serializer;
 
@@ -109,7 +110,8 @@ class JsonSerializeTest extends PHPUnit_Framework_TestCase
             ->setRange(true)
             ->setSort(Navigation\Order::Value_Ascending)
             ->setMetadata(array(self::$OBJ_METADATA))
-            ->setRefinements(array(self::$OBJ_REFINEMENT_RANGE, self::$OBJ_REFINEMENT_VALUE));
+            ->setRefinements(array(self::$OBJ_REFINEMENT_RANGE, self::$OBJ_REFINEMENT_VALUE))
+            ->setMoreRefinements(true);
 
         self::$OBJ_RECORD = new Record();
         self::$OBJ_RECORD->setId("fw90314jh289t")
@@ -170,12 +172,36 @@ class JsonSerializeTest extends PHPUnit_Framework_TestCase
         self::$OBJ_REQUEST->pruneRefinements = true;
         self::$OBJ_REQUEST->returnBinary = false;
         self::$OBJ_REQUEST->query = "cantaloupe";
+        self::$OBJ_REQUEST->refinementQuery = "cranberry";
         self::$OBJ_REQUEST->sort = self::$OBJ_SORT;
         self::$OBJ_REQUEST->fields = array("pineapple", "grape", "clementine");
         self::$OBJ_REQUEST->orFields = array("pumpernickel", "rye");
         self::$OBJ_REQUEST->refinements = array(self::$OBJ_REFINEMENT_RANGE, self::$OBJ_REFINEMENT_VALUE);
         self::$OBJ_REQUEST->customUrlParams = array(self::$OBJ_CUSTOM_URL_PARAM);
+        self::$OBJ_REQUEST->wildcardSearchEnabled = true;
         self::$OBJ_REQUEST->restrictNavigation = self::$OBJ_RESTRICT_NAVIGATION;
+
+        self::$OBJ_REFINEMENTS_REQUEST = new RefinementsRequest();
+        self::$OBJ_REFINEMENTS_REQUEST->clientKey = "adf7h8er7h2r";
+        self::$OBJ_REFINEMENTS_REQUEST->collection = "ducks";
+        self::$OBJ_REFINEMENTS_REQUEST->area = "surface";
+        self::$OBJ_REFINEMENTS_REQUEST->skip = 12;
+        self::$OBJ_REFINEMENTS_REQUEST->pageSize = 30;
+        self::$OBJ_REFINEMENTS_REQUEST->biasingProfile = "ballooning";
+        self::$OBJ_REFINEMENTS_REQUEST->language = "en";
+        self::$OBJ_REFINEMENTS_REQUEST->pruneRefinements = true;
+        self::$OBJ_REFINEMENTS_REQUEST->returnBinary = false;
+        self::$OBJ_REFINEMENTS_REQUEST->query = "cantaloupe";
+        self::$OBJ_REFINEMENTS_REQUEST->refinementQuery = "cranberry";
+        self::$OBJ_REFINEMENTS_REQUEST->sort = self::$OBJ_SORT;
+        self::$OBJ_REFINEMENTS_REQUEST->fields = array("pineapple", "grape", "clementine");
+        self::$OBJ_REFINEMENTS_REQUEST->orFields = array("pumpernickel", "rye");
+        self::$OBJ_REFINEMENTS_REQUEST->refinements = array(self::$OBJ_REFINEMENT_RANGE, self::$OBJ_REFINEMENT_VALUE);
+        self::$OBJ_REFINEMENTS_REQUEST->customUrlParams = array(self::$OBJ_CUSTOM_URL_PARAM);
+        self::$OBJ_REFINEMENTS_REQUEST->wildcardSearchEnabled = true;
+        self::$OBJ_REFINEMENTS_REQUEST->restrictNavigation = self::$OBJ_RESTRICT_NAVIGATION;
+        self::$OBJ_REFINEMENTS_REQUEST->originalQuery = self::$OBJ_REQUEST;
+        self::$OBJ_REFINEMENTS_REQUEST->navigationName = "height";
     }
 
     public function setUp()
@@ -191,6 +217,7 @@ class JsonSerializeTest extends PHPUnit_Framework_TestCase
 
     /**
      * @param object $obj
+     *
      * @return string
      */
     private function serialize($obj)
@@ -212,7 +239,7 @@ class JsonSerializeTest extends PHPUnit_Framework_TestCase
 
     public function testEncodeCustomUrlParam()
     {
-        $this->assertJsonStringEqualsJsonString(self::$JSON_CUSTOM_URL_PARAM,
+        $this->assertJsonStringEqualsJsonString(JsonDeserializeTest::$JSON_CUSTOM_URL_PARAM,
             $this->serialize(self::$OBJ_CUSTOM_URL_PARAM));
     }
 
@@ -272,7 +299,7 @@ class JsonSerializeTest extends PHPUnit_Framework_TestCase
 
     public function testEncodeSort()
     {
-        $this->assertJsonStringEqualsJsonString(self::$JSON_SORT, $this->serialize(self::$OBJ_SORT));
+        $this->assertJsonStringEqualsJsonString(JsonDeserializeTest::$JSON_SORT, $this->serialize(self::$OBJ_SORT));
     }
 
     public function testEncodeTemplate()
@@ -289,14 +316,13 @@ class JsonSerializeTest extends PHPUnit_Framework_TestCase
 
     public function testEncodeRequest()
     {
-        $this->assertJsonStringEqualsJsonString('{"clientKey":"adf7h8er7h2r","collection":"ducks",' .
-            '"area":"surface","skip":12,"pageSize":30,"biasingProfile":"ballooning","language":"en",' .
-            '"pruneRefinements":true,"returnBinary":false,"query":"cantaloupe",' .
-            '"sort":' . self::$JSON_SORT . ',"fields":["pineapple","grape","clementine"],' .
-            '"orFields":["pumpernickel","rye"],"refinements":[' . JsonDeserializeTest::$JSON_REFINEMENT_RANGE . ',' .
-            JsonDeserializeTest::$JSON_REFINEMENT_VALUE . '],' . '"customUrlParams":[' . self::$JSON_CUSTOM_URL_PARAM .
-            '],' . '"restrictNavigation":' . JsonDeserializeTest::$JSON_RESTRICT_NAVIGATION . '}',
-            $this->serialize(self::$OBJ_REQUEST));
+        $this->assertJsonStringEqualsJsonString(JsonDeserializeTest::$JSON_REQUEST, $this->serialize(self::$OBJ_REQUEST));
+    }
+
+    public function testEncodeRefinementsRequest()
+    {
+        $this->assertJsonStringEqualsJsonString('{"originalQuery":' . JsonDeserializeTest::$JSON_REQUEST .
+            ',"navigationName":"height"}', $this->serialize(self::$OBJ_REFINEMENTS_REQUEST));
     }
 }
 

--- a/tests/API/QueryTest.php
+++ b/tests/API/QueryTest.php
@@ -8,7 +8,20 @@ use Httpful\Response;
 
 class QueryTest extends PHPUnit_Framework_TestCase
 {
-    const QUERY = '{"clientKey":"XXXX-XXXX-XXXX-XXXX","collection":"testproducts","area":"Production","biasingProfile":"testProfile","language":"en","query":"the","sort":{"field":"price","order":"Descending"},"fields":["brand","category","height"],"orFields":["price","color"],"refinements":[{"navigationName":"green","exclude":true,"high":"delicious","low":"atrocious","type":"Range"},{"navigationName":"green","exclude":false,"value":"malaise","type":"Value"}],"customUrlParams":[{"key":"guava","value":"mango"}],"skip":20,"pageSize":14,"disableAutocorrection":true,"pruneRefinements":false,"wildcardSearchEnabled":true}';
+    private static $QUERY;
+    private static $REFINEMENTS_QUERY;
+
+    public static function init()
+    {
+        self::$QUERY = '{"clientKey":"XXXX-XXXX-XXXX-XXXX","collection":"testproducts","area":"Production",' .
+            '"biasingProfile":"testProfile","language":"en","query":"the","sort":{"field":"price","order":"Descending"},' .
+            '"fields":["brand","category","height"],"orFields":["price","color"],"refinements":[{"navigationName":"green",' .
+            '"exclude":true,"high":"delicious","low":"atrocious","type":"Range"},{"navigationName":"green","exclude":false,' .
+            '"value":"malaise","type":"Value"}],"customUrlParams":[{"key":"guava","value":"mango"}],"skip":20,"pageSize":14,' .
+            '"disableAutocorrection":true,"pruneRefinements":false,"wildcardSearchEnabled":true}';
+
+        self::$REFINEMENTS_QUERY = '{"originalQuery":' . self::$QUERY . ',"navigationName":"height"}';
+    }
 
     public function testSerializeQuery()
     {
@@ -30,6 +43,31 @@ class QueryTest extends PHPUnit_Framework_TestCase
         $query->setWildcardSearchEnabled(true);
 
         $json = $query->getBridgeJson('XXXX-XXXX-XXXX-XXXX');
-        $this->assertEquals(self::QUERY, $json);
+        $this->assertEquals(self::$QUERY, $json);
+    }
+
+    public function testSerializeRefinementsQuery()
+    {
+        $query = new Query();
+        $query->setQuery('the');
+        $query->setSort(JsonSerializeTest::$OBJ_SORT);
+        $query->setSkip(20);
+        $query->setPageSize(14);
+        $query->setCollection('testproducts');
+        $query->setArea('Production');
+        $query->setBiasingProfile('testProfile');
+        $query->setLanguage('en');
+        $query->setPruneRefinements(false);
+        $query->setDisableAutocorrection(true);
+        $query->setCustomUrlParams(array(JsonSerializeTest::$OBJ_CUSTOM_URL_PARAM));
+        $query->setNavigations(array(JsonSerializeTest::$OBJ_NAVIGATION));
+        $query->addFields(array("brand", "category", "height"));
+        $query->addOrFields(array("price", "color"));
+        $query->setWildcardSearchEnabled(true);
+
+        $json = $query->getBridgeRefinementsJson('XXXX-XXXX-XXXX-XXXX', 'height');
+        $this->assertEquals(self::$REFINEMENTS_QUERY, $json);
     }
 }
+
+QueryTest::init();


### PR DESCRIPTION
Created by: willwarren <img height="16px" src="https://avatars.githubusercontent.com/u/1261268?v=3">
Parent groupby/issues#720
Related to groupby/bindle#1122

If the refinements for available navigation come back with more than twenty values, you now get a has more flag.  In the quickstart Java / PHP we need to implement this.
- [ ] groupby/bindle#1433
