### PR TITLE
Quickstart to support more refinements

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,5 @@
+- <a href="https://github.com/groupby/issues/issues/720">iss12</a> Quickstart to support more refinements
+
 - <a href="https://github.com/groupby/issues/issues/672">iss10</a> RestrictNavigation for elasticsearch
 
 Changelog


### PR DESCRIPTION
Created by: willwarren <img height="16px" src="https://avatars.githubusercontent.com/u/1261268?v=3">
Parent groupby/issues#720

If the refinements for available navigation come back with more than twenty values, you now get a has more flag.  In the quickstart Java / PHP we need to implement this.
- [ ] groupby/bindle#1433
